### PR TITLE
release: flutter_bloc_one_shot v0.2.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable MD041 -->
+## Summary
+
+<!-- What does this PR do? Keep it brief (1-3 bullet points). -->
+
+-
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor (no functional changes)
+- [ ] Documentation update
+
+## Packages affected
+
+<!-- Check all that apply. -->
+
+- [ ] `bloc_one_shot`
+- [ ] `flutter_bloc_one_shot`
+- [ ] `bloc_one_shot_test`
+
+## Checklist
+
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] All new and existing tests pass (`dart test` / `flutter test`)
+- [ ] Static analysis passes (`dart analyze packages/`)
+- [ ] Code is formatted (`dart format packages/`)
+- [ ] I have updated the CHANGELOG of the affected packages
+- [ ] I have updated the README if the public API changed

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage/
 
 # Melos
 .melos/
+
+# Docs (local drafts)
+docs/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Modeling side effects as state causes:
 | Package | Description | Version |
 | --- | --- | --- |
 | [`bloc_one_shot`](packages/bloc_one_shot/) | Core Dart package — `EffectController`, `SideEffectMixin`, `EffectObserver` | `0.1.0` |
-| [`flutter_bloc_one_shot`](packages/flutter_bloc_one_shot/) | Flutter widgets — `SideEffectListener`, `SideEffectConsumer`, `MultipleSideEffectListener` | `0.2.0` |
+| [`flutter_bloc_one_shot`](packages/flutter_bloc_one_shot/) | Flutter widgets — `SideEffectProvider`, `SideEffectListener`, `SideEffectConsumer`, `MultipleSideEffectListener` | `0.2.0` |
 | [`bloc_one_shot_test`](packages/bloc_one_shot_test/) | Test utilities — `blocEffectTest()` | `0.1.0` |
 
 ## Installation
@@ -127,6 +127,25 @@ SideEffectListener<LoginCubit, LoginEffect>(
 )
 ```
 
+**`SideEffectProvider`** — creates/provides a Bloc and listens to effects in one widget:
+
+```dart
+SideEffectProvider<LoginCubit, LoginEffect>(
+  create: (_) => LoginCubit(),
+  listener: (context, effect) {
+    switch (effect) {
+      case NavigateToHome():
+        Navigator.of(context).pushReplacementNamed('/home');
+      case ShowErrorSnackbar(:final message):
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+    }
+  },
+  child: LoginForm(),
+)
+```
+
 **`MultipleSideEffectListener`** — listens to effects from multiple blocs without nesting:
 
 ```dart
@@ -197,6 +216,17 @@ blocEffectTest<LoginCubit, LoginState, LoginEffect>(
 | --- | --- |
 | `Stream<Effect> effects` | The stream of side effects |
 | `void emitEffect(Effect effect)` | Emits a side effect |
+
+### `SideEffectProvider<B, E>`
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `create` | `B Function(BuildContext)` | Creates the Bloc (default constructor) |
+| `value` | `B` | Existing Bloc instance (`.value` constructor) |
+| `listener` | `void Function(BuildContext, E)` | Called once per effect |
+| `listenWhen` | `bool Function(E)?` | Optional effect filter |
+| `lazy` | `bool` | Lazily create the Bloc (default: `true`) |
+| `child` | `Widget?` | Child widget |
 
 ### `SideEffectListener<B, E>`
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![flutter_bloc_one_shot](https://img.shields.io/pub/v/flutter_bloc_one_shot.svg?label=flutter_bloc_one_shot)](https://pub.dev/packages/flutter_bloc_one_shot)
 [![bloc_one_shot_test](https://img.shields.io/pub/v/bloc_one_shot_test.svg?label=bloc_one_shot_test)](https://pub.dev/packages/bloc_one_shot_test)
 [![codecov](https://codecov.io/gh/AltumStack/flutter_bloc_one_shot/branch/master/graph/badge.svg)](https://app.codecov.io/github/AltumStack/flutter_bloc_one_shot)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 A side-effect system for Flutter BLoC. Separate **what the screen IS** (state) from **what the screen DOES** (effects).
+
+📖 [Read the full article on Medium](https://medium.com/@amarturelo/side-effects-in-flutter-bloc-2026-transient-states-or-separate-stream-eef506b91a10)
 
 Side effects like navigation, snackbars, and dialogs are ephemeral one-shot actions that don't belong in persistent state. `bloc_one_shot` introduces a **dual-channel architecture** where your Bloc exposes two outputs: **State** and **Effect**.
 
@@ -31,17 +34,17 @@ Modeling side effects as state causes:
 
 ## Packages
 
-| Package | Description | pub.dev |
-|---|---|---|
-| [`bloc_one_shot`](packages/bloc_one_shot/) | Core Dart package — `EffectController`, `SideEffectMixin`, `EffectObserver` | — |
-| [`flutter_bloc_one_shot`](packages/flutter_bloc_one_shot/) | Flutter widgets — `SideEffectListener`, `SideEffectConsumer` | — |
-| [`bloc_one_shot_test`](packages/bloc_one_shot_test/) | Test utilities — `blocEffectTest()` | — |
+| Package | Description | Version |
+| --- | --- | --- |
+| [`bloc_one_shot`](packages/bloc_one_shot/) | Core Dart package — `EffectController`, `SideEffectMixin`, `EffectObserver` | `0.1.0` |
+| [`flutter_bloc_one_shot`](packages/flutter_bloc_one_shot/) | Flutter widgets — `SideEffectListener`, `SideEffectConsumer`, `MultipleSideEffectListener` | `0.2.0` |
+| [`bloc_one_shot_test`](packages/bloc_one_shot_test/) | Test utilities — `blocEffectTest()` | `0.1.0` |
 
 ## Installation
 
 ```yaml
 dependencies:
-  flutter_bloc_one_shot: ^0.1.0
+  flutter_bloc_one_shot: ^0.2.0
 ```
 
 `flutter_bloc_one_shot` re-exports `bloc_one_shot`, so a single dependency is all you need.
@@ -124,6 +127,22 @@ SideEffectListener<LoginCubit, LoginEffect>(
 )
 ```
 
+**`MultipleSideEffectListener`** — listens to effects from multiple blocs without nesting:
+
+```dart
+MultipleSideEffectListener(
+  listeners: [
+    SideEffectListener<AuthBloc, AuthEffect>(
+      listener: (context, effect) { /* ... */ },
+    ),
+    SideEffectListener<NotificationBloc, NotificationEffect>(
+      listener: (context, effect) { /* ... */ },
+    ),
+  ],
+  child: HomePage(),
+)
+```
+
 **`SideEffectConsumer`** — combines state builder + effect listener:
 
 ```dart
@@ -175,23 +194,30 @@ blocEffectTest<LoginCubit, LoginState, LoginEffect>(
 ### `SideEffectMixin<State, Effect>`
 
 | Member | Description |
-|---|---|
+| --- | --- |
 | `Stream<Effect> effects` | The stream of side effects |
 | `void emitEffect(Effect effect)` | Emits a side effect |
 
 ### `SideEffectListener<B, E>`
 
 | Parameter | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `listener` | `void Function(BuildContext, E)` | Called once per effect |
 | `bloc` | `B?` | Optional — resolved via `context.read<B>()` |
 | `listenWhen` | `bool Function(E)?` | Optional effect filter |
 | `child` | `Widget?` | Child widget |
 
+### `MultipleSideEffectListener`
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `listeners` | `List<SingleChildWidget>` | List of `SideEffectListener` widgets |
+| `child` | `Widget` | Child widget rendered below all listeners |
+
 ### `SideEffectConsumer<B, S, E>`
 
 | Parameter | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `builder` | `Widget Function(BuildContext, S)` | Builds UI from state |
 | `listener` | `void Function(BuildContext, E)` | Called once per effect |
 | `bloc` | `B?` | Optional — resolved via `context.read<B>()` |
@@ -208,7 +234,7 @@ Set `EffectObserver.instance` at app startup to observe all effects globally.
 
 ## How Buffering Works
 
-```
+```text
 Timeline:
   Bloc created        → emitEffect(A)  → emitEffect(B)  → Widget subscribes → emitEffect(C)
   [no listener]         [buffered]        [buffered]        [flush A, B]       [delivered live]
@@ -236,6 +262,25 @@ dart analyze packages/
 # Format check
 dart format --set-exit-if-changed packages/
 ```
+
+## Contributing
+
+Contributions are welcome! To get started:
+
+1. Fork the repo and create your branch from `develop`
+2. Run `dart pub get` to resolve dependencies
+3. Make your changes and add tests
+4. Ensure all checks pass:
+
+   ```bash
+   dart test packages/bloc_one_shot/test/ packages/bloc_one_shot_test/test/
+   flutter test packages/flutter_bloc_one_shot/test/
+   dart analyze packages/
+   dart format --set-exit-if-changed packages/
+   ```
+
+5. Update the CHANGELOG of the affected packages
+6. Open a pull request — the [PR template](.github/PULL_REQUEST_TEMPLATE.md) will guide you through the required information
 
 ## License
 

--- a/packages/flutter_bloc_one_shot/CHANGELOG.md
+++ b/packages/flutter_bloc_one_shot/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `MultipleSideEffectListener` widget to merge multiple `SideEffectListener` widgets without nesting.
 - Refactor `SideEffectListener` to extend `SingleChildStatefulWidget` for compatibility with `MultipleSideEffectListener`.
 - Add `provider` as a direct dependency.
+- Add `SideEffectProvider` widget that combines `BlocProvider` and `SideEffectListener` into a single widget, reducing boilerplate for the common create-provide-listen pattern.
 
 ## 0.1.0
 

--- a/packages/flutter_bloc_one_shot/CHANGELOG.md
+++ b/packages/flutter_bloc_one_shot/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changelog
+
+## 0.2.0
+
+- Add `MultipleSideEffectListener` widget to merge multiple `SideEffectListener` widgets without nesting.
+- Refactor `SideEffectListener` to extend `SingleChildStatefulWidget` for compatibility with `MultipleSideEffectListener`.
+- Add `provider` as a direct dependency.
+
 ## 0.1.0
 
 - Initial release.

--- a/packages/flutter_bloc_one_shot/README.md
+++ b/packages/flutter_bloc_one_shot/README.md
@@ -3,7 +3,7 @@
 [![pub package](https://img.shields.io/pub/v/flutter_bloc_one_shot.svg)](https://pub.dev/packages/flutter_bloc_one_shot)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Flutter widgets for [`bloc_one_shot`](https://pub.dev/packages/bloc_one_shot). Provides `SideEffectListener` and `SideEffectConsumer` that mirror the `BlocListener`/`BlocConsumer` API you already know.
+Flutter widgets for [`bloc_one_shot`](https://pub.dev/packages/bloc_one_shot). Provides `SideEffectListener`, `SideEffectConsumer`, and `MultipleSideEffectListener` that mirror the `BlocListener`/`BlocConsumer`/`MultiBlocListener` API you already know.
 
 > **For test utilities** (`blocEffectTest`), see [`bloc_one_shot_test`](https://pub.dev/packages/bloc_one_shot_test).
 
@@ -11,7 +11,7 @@ Flutter widgets for [`bloc_one_shot`](https://pub.dev/packages/bloc_one_shot). P
 
 ```yaml
 dependencies:
-  flutter_bloc_one_shot: ^0.1.0
+  flutter_bloc_one_shot: ^0.2.0
 ```
 
 This package re-exports `bloc_one_shot`, so you only need a single dependency for both core and widgets.
@@ -76,7 +76,7 @@ SideEffectListener<LoginCubit, LoginEffect>(
 #### Parameters
 
 | Parameter | Type | Required | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `listener` | `void Function(BuildContext, E)` | Yes | Called once per effect |
 | `bloc` | `B?` | No | If omitted, resolved via `context.read<B>()` |
 | `listenWhen` | `bool Function(E)?` | No | Filter — listener only fires when this returns `true` |
@@ -136,10 +136,56 @@ SideEffectListener<LoginCubit, LoginEffect>(
 
 When a widget unmounts (e.g. during navigation) and remounts later, any effects emitted during the gap are buffered and delivered to the new listener:
 
-```
+```text
 Widget mounts     →  effect A (delivered)  →  Widget unmounts
 Widget remounts   →  effect B (was buffered, now delivered)  →  effect C (delivered live)
 ```
+
+---
+
+### `MultipleSideEffectListener`
+
+Merges multiple `SideEffectListener` widgets into a single widget tree, avoiding deeply nested listeners. Mirrors `MultiBlocListener` from `flutter_bloc`.
+
+```dart
+MultipleSideEffectListener(
+  listeners: [
+    SideEffectListener<AuthBloc, AuthEffect>(
+      listener: (context, effect) {
+        // Handle auth effects (e.g. session expired → navigate to login)
+      },
+    ),
+    SideEffectListener<NotificationBloc, NotificationEffect>(
+      listener: (context, effect) {
+        // Handle notification effects (e.g. show snackbar)
+      },
+    ),
+  ],
+  child: HomePage(),
+)
+```
+
+This is equivalent to nesting them manually:
+
+```dart
+// Without MultipleSideEffectListener (nesting hell)
+SideEffectListener<AuthBloc, AuthEffect>(
+  listener: (context, effect) { /* ... */ },
+  child: SideEffectListener<NotificationBloc, NotificationEffect>(
+    listener: (context, effect) { /* ... */ },
+    child: HomePage(),
+  ),
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `listeners` | `List<SingleChildWidget>` | Yes | List of `SideEffectListener` widgets |
+| `child` | `Widget` | Yes | Child widget rendered below all listeners |
+
+All `SideEffectListener` features (`listenWhen`, `bloc`, context resolution) work inside `MultipleSideEffectListener`.
 
 ---
 
@@ -172,7 +218,7 @@ SideEffectConsumer<LoginCubit, LoginState, LoginEffect>(
 #### Parameters
 
 | Parameter | Type | Required | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `builder` | `Widget Function(BuildContext, S)` | Yes | Builds UI from state |
 | `listener` | `void Function(BuildContext, E)` | Yes | Called once per effect |
 | `bloc` | `B?` | No | If omitted, resolved via `context.read<B>()` |
@@ -201,8 +247,9 @@ SideEffectConsumer<CounterCubit, int, CounterEffect>(
 ## When to Use What
 
 | Scenario | Widget |
-|---|---|
+| --- | --- |
 | React to effects only (navigation, snackbar) | `SideEffectListener` |
+| React to effects from multiple blocs | `MultipleSideEffectListener` |
 | Build UI from state only | `BlocBuilder` (from `flutter_bloc`) |
 | Build UI from state + react to effects | `SideEffectConsumer` |
 | Listen to state changes (not effects) | `BlocListener` (from `flutter_bloc`) |

--- a/packages/flutter_bloc_one_shot/README.md
+++ b/packages/flutter_bloc_one_shot/README.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable MD024 -->
 # flutter_bloc_one_shot
 
 [![pub package](https://img.shields.io/pub/v/flutter_bloc_one_shot.svg)](https://pub.dev/packages/flutter_bloc_one_shot)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Flutter widgets for [`bloc_one_shot`](https://pub.dev/packages/bloc_one_shot). Provides `SideEffectListener`, `SideEffectConsumer`, and `MultipleSideEffectListener` that mirror the `BlocListener`/`BlocConsumer`/`MultiBlocListener` API you already know.
+Flutter widgets for [`bloc_one_shot`](https://pub.dev/packages/bloc_one_shot). Provides `SideEffectProvider`, `SideEffectListener`, `SideEffectConsumer`, and `MultipleSideEffectListener` that mirror the `BlocProvider`/`BlocListener`/`BlocConsumer`/`MultiBlocListener` API you already know.
 
 > **For test utilities** (`blocEffectTest`), see [`bloc_one_shot_test`](https://pub.dev/packages/bloc_one_shot_test).
 
@@ -143,6 +144,64 @@ Widget remounts   →  effect B (was buffered, now delivered)  →  effect C (de
 
 ---
 
+### `SideEffectProvider`
+
+Combines `BlocProvider` and `SideEffectListener` into a single widget. Use this when you need to create (or provide) a Bloc **and** listen to its effects in one step.
+
+```dart
+SideEffectProvider<LoginCubit, LoginEffect>(
+  create: (_) => LoginCubit(),
+  listener: (context, effect) {
+    switch (effect) {
+      case NavigateToHome():
+        Navigator.of(context).pushReplacementNamed('/home');
+      case ShowErrorSnackbar(:final message):
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+    }
+  },
+  child: LoginForm(),
+)
+```
+
+This is equivalent to:
+
+```dart
+BlocProvider(
+  create: (_) => LoginCubit(),
+  child: SideEffectListener<LoginCubit, LoginEffect>(
+    listener: (context, effect) { /* ... */ },
+    child: LoginForm(),
+  ),
+)
+```
+
+#### `.value` constructor
+
+Use `SideEffectProvider.value` to provide an existing Bloc instance (without closing it on dispose):
+
+```dart
+SideEffectProvider<LoginCubit, LoginEffect>.value(
+  value: existingCubit,
+  listener: (context, effect) { /* ... */ },
+  child: LoginForm(),
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `create` | `B Function(BuildContext)` | Yes* | Creates the Bloc (*default constructor only) |
+| `value` | `B` | Yes* | Existing Bloc instance (*.value constructor only) |
+| `listener` | `void Function(BuildContext, E)` | Yes | Called once per effect |
+| `listenWhen` | `bool Function(E)?` | No | Filter — listener only fires when this returns `true` |
+| `lazy` | `bool` | No | Whether to lazily create the Bloc (default: `true`) |
+| `child` | `Widget?` | No | Child widget |
+
+---
+
 ### `MultipleSideEffectListener`
 
 Merges multiple `SideEffectListener` widgets into a single widget tree, avoiding deeply nested listeners. Mirrors `MultiBlocListener` from `flutter_bloc`.
@@ -249,6 +308,7 @@ SideEffectConsumer<CounterCubit, int, CounterEffect>(
 | Scenario | Widget |
 | --- | --- |
 | React to effects only (navigation, snackbar) | `SideEffectListener` |
+| Create/provide a Bloc + listen to effects | `SideEffectProvider` |
 | React to effects from multiple blocs | `MultipleSideEffectListener` |
 | Build UI from state only | `BlocBuilder` (from `flutter_bloc`) |
 | Build UI from state + react to effects | `SideEffectConsumer` |

--- a/packages/flutter_bloc_one_shot/lib/flutter_bloc_one_shot.dart
+++ b/packages/flutter_bloc_one_shot/lib/flutter_bloc_one_shot.dart
@@ -5,5 +5,6 @@
 library flutter_bloc_one_shot;
 
 export 'package:bloc_one_shot/bloc_one_shot.dart';
+export 'src/multiple_side_effect_listener.dart';
 export 'src/side_effect_consumer.dart';
 export 'src/side_effect_listener.dart';

--- a/packages/flutter_bloc_one_shot/lib/flutter_bloc_one_shot.dart
+++ b/packages/flutter_bloc_one_shot/lib/flutter_bloc_one_shot.dart
@@ -8,3 +8,4 @@ export 'package:bloc_one_shot/bloc_one_shot.dart';
 export 'src/multiple_side_effect_listener.dart';
 export 'src/side_effect_consumer.dart';
 export 'src/side_effect_listener.dart';
+export 'src/side_effect_provider.dart';

--- a/packages/flutter_bloc_one_shot/lib/src/multiple_side_effect_listener.dart
+++ b/packages/flutter_bloc_one_shot/lib/src/multiple_side_effect_listener.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+
+/// Merges multiple [SideEffectListener] widgets into one widget tree.
+///
+/// Improves readability and eliminates nesting when listening to
+/// side effects from multiple blocs.
+///
+/// ```dart
+/// MultipleSideEffectListener(
+///   listeners: [
+///     SideEffectListener<AuthBloc, AuthEffect>(
+///       listener: (context, effect) { /* ... */ },
+///     ),
+///     SideEffectListener<NavBloc, NavEffect>(
+///       listener: (context, effect) { /* ... */ },
+///     ),
+///   ],
+///   child: MyWidget(),
+/// )
+/// ```
+class MultipleSideEffectListener extends MultiProvider {
+  /// Creates a [MultipleSideEffectListener] that nests multiple
+  /// [SideEffectListener] widgets.
+  MultipleSideEffectListener({
+    required List<SingleChildWidget> listeners,
+    required Widget child,
+    super.key,
+  }) : super(providers: listeners, child: child);
+}

--- a/packages/flutter_bloc_one_shot/lib/src/side_effect_listener.dart
+++ b/packages/flutter_bloc_one_shot/lib/src/side_effect_listener.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bloc_one_shot/bloc_one_shot.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:provider/single_child_widget.dart';
 
 /// Signature for the `listener` callback in [SideEffectListener].
 typedef SideEffectListenerCallback<E> =
@@ -37,7 +38,7 @@ typedef SideEffectListenerCondition<E> = bool Function(E effect);
 /// )
 /// ```
 class SideEffectListener<B extends BlocBase<dynamic>, E>
-    extends StatefulWidget {
+    extends SingleChildStatefulWidget {
   /// Creates a [SideEffectListener].
   ///
   /// The [listener] is required and called once per emitted effect.
@@ -48,7 +49,7 @@ class SideEffectListener<B extends BlocBase<dynamic>, E>
     this.listenWhen,
     this.child,
     super.key,
-  });
+  }) : super(child: child);
 
   /// The bloc or cubit to listen to.
   ///
@@ -66,12 +67,12 @@ class SideEffectListener<B extends BlocBase<dynamic>, E>
   final Widget? child;
 
   @override
-  State<SideEffectListener<B, E>> createState() =>
+  SingleChildState<SideEffectListener<B, E>> createState() =>
       _SideEffectListenerState<B, E>();
 }
 
 class _SideEffectListenerState<B extends BlocBase<dynamic>, E>
-    extends State<SideEffectListener<B, E>> {
+    extends SingleChildState<SideEffectListener<B, E>> {
   StreamSubscription<E>? _subscription;
   late B _bloc;
 
@@ -138,5 +139,6 @@ class _SideEffectListenerState<B extends BlocBase<dynamic>, E>
   }
 
   @override
-  Widget build(BuildContext context) => widget.child ?? const SizedBox.shrink();
+  Widget buildWithChild(BuildContext context, Widget? child) =>
+      child ?? const SizedBox.shrink();
 }

--- a/packages/flutter_bloc_one_shot/lib/src/side_effect_provider.dart
+++ b/packages/flutter_bloc_one_shot/lib/src/side_effect_provider.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'side_effect_listener.dart';
+
+/// A widget that combines [BlocProvider] and [SideEffectListener] into a single
+/// convenience widget.
+///
+/// Instead of nesting a [BlocProvider] around a [SideEffectListener]:
+///
+/// ```dart
+/// BlocProvider(
+///   create: (_) => AuthBloc(),
+///   child: SideEffectListener<AuthBloc, AuthEffect>(
+///     listener: (context, effect) { /* ... */ },
+///     child: AuthPage(),
+///   ),
+/// )
+/// ```
+///
+/// You can use [SideEffectProvider]:
+///
+/// ```dart
+/// SideEffectProvider<AuthBloc, AuthEffect>(
+///   create: (_) => AuthBloc(),
+///   listener: (context, effect) { /* ... */ },
+///   child: AuthPage(),
+/// )
+/// ```
+class SideEffectProvider<B extends BlocBase<dynamic>, E>
+    extends StatelessWidget {
+  /// Creates a [SideEffectProvider] that creates and provides a new Bloc.
+  ///
+  /// The Bloc is created using [create] and automatically closed when the
+  /// widget is disposed (same behavior as [BlocProvider]).
+  const SideEffectProvider({
+    required this.create,
+    required this.listener,
+    this.listenWhen,
+    this.lazy = true,
+    this.child,
+    super.key,
+  }) : _value = null;
+
+  /// Creates a [SideEffectProvider] that provides an existing Bloc instance.
+  ///
+  /// The Bloc is **not** closed when the widget is disposed (same behavior as
+  /// [BlocProvider.value]).
+  const SideEffectProvider.value({
+    required B value,
+    required this.listener,
+    this.listenWhen,
+    this.child,
+    super.key,
+  }) : _value = value,
+       create = null,
+       lazy = true;
+
+  /// Function that creates the Bloc. Only used by the default constructor.
+  final B Function(BuildContext)? create;
+
+  /// An existing Bloc instance. Only used by the `.value` constructor.
+  final B? _value;
+
+  /// Called once per side effect emitted by the Bloc.
+  final SideEffectListenerCallback<E> listener;
+
+  /// Optional filter. If provided, [listener] is only called when this
+  /// returns `true` for the given effect.
+  final SideEffectListenerCondition<E>? listenWhen;
+
+  /// Whether to lazily create the Bloc. Defaults to `true`.
+  final bool lazy;
+
+  /// The child widget.
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_value != null) {
+      return BlocProvider<B>.value(
+        value: _value,
+        child: SideEffectListener<B, E>(
+          bloc: _value,
+          listener: listener,
+          listenWhen: listenWhen,
+          child: child,
+        ),
+      );
+    }
+
+    return BlocProvider<B>(
+      create: create!,
+      lazy: lazy,
+      child: SideEffectListener<B, E>(
+        listener: listener,
+        listenWhen: listenWhen,
+        child: child,
+      ),
+    );
+  }
+}

--- a/packages/flutter_bloc_one_shot/pubspec.yaml
+++ b/packages/flutter_bloc_one_shot/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_bloc_one_shot
 description: >
   Flutter widgets for bloc_one_shot. Provides SideEffectListener and SideEffectConsumer
   widgets that mirror BlocListener/BlocConsumer API conventions.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/aspect-build/bloc_one_shot
 repository: https://github.com/aspect-build/bloc_one_shot/tree/main/packages/flutter_bloc_one_shot
 
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^9.0.0
   bloc_one_shot: ^0.1.0
+  provider: ">=6.0.0 <7.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_bloc_one_shot/pubspec.yaml
+++ b/packages/flutter_bloc_one_shot/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_one_shot
 description: >
-  Flutter widgets for bloc_one_shot. Provides SideEffectListener and SideEffectConsumer
-  widgets that mirror BlocListener/BlocConsumer API conventions.
+  Flutter widgets for bloc_one_shot. Provides SideEffectProvider, SideEffectListener,
+  and SideEffectConsumer widgets that mirror BlocProvider/BlocListener/BlocConsumer API conventions.
 version: 0.2.0
 homepage: https://github.com/aspect-build/bloc_one_shot
 repository: https://github.com/aspect-build/bloc_one_shot/tree/main/packages/flutter_bloc_one_shot

--- a/packages/flutter_bloc_one_shot/test/multiple_side_effect_listener_test.dart
+++ b/packages/flutter_bloc_one_shot/test/multiple_side_effect_listener_test.dart
@@ -93,8 +93,9 @@ void main() {
       await cubitB.close();
     });
 
-    testWidgets('each listener receives effects only from its bloc',
-        (tester) async {
+    testWidgets('each listener receives effects only from its bloc', (
+      tester,
+    ) async {
       final cubitA = CubitA();
       final cubitB = CubitB();
       final effectsA = <EffectA>[];
@@ -134,8 +135,7 @@ void main() {
       await cubitB.close();
     });
 
-    testWidgets('both listeners receive effects independently',
-        (tester) async {
+    testWidgets('both listeners receive effects independently', (tester) async {
       final cubitA = CubitA();
       final cubitB = CubitB();
       final effectsA = <EffectA>[];
@@ -172,8 +172,9 @@ void main() {
       await cubitB.close();
     });
 
-    testWidgets('works with blocs provided via BlocProvider context',
-        (tester) async {
+    testWidgets('works with blocs provided via BlocProvider context', (
+      tester,
+    ) async {
       final cubitA = CubitA();
       final cubitB = CubitB();
       final effectsA = <EffectA>[];

--- a/packages/flutter_bloc_one_shot/test/multiple_side_effect_listener_test.dart
+++ b/packages/flutter_bloc_one_shot/test/multiple_side_effect_listener_test.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_bloc_one_shot/flutter_bloc_one_shot.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// --- Test helpers ---
+
+sealed class EffectA {}
+
+class EffectA1 extends EffectA {
+  final String value;
+  EffectA1(this.value);
+
+  @override
+  bool operator ==(Object other) => other is EffectA1 && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'EffectA1($value)';
+}
+
+sealed class EffectB {}
+
+class EffectB1 extends EffectB {
+  final int code;
+  EffectB1(this.code);
+
+  @override
+  bool operator ==(Object other) => other is EffectB1 && other.code == code;
+
+  @override
+  int get hashCode => code.hashCode;
+
+  @override
+  String toString() => 'EffectB1($code)';
+}
+
+class EffectB2 extends EffectB {
+  @override
+  bool operator ==(Object other) => other is EffectB2;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'EffectB2()';
+}
+
+class CubitA extends Cubit<int> with SideEffectMixin<int, EffectA> {
+  CubitA() : super(0);
+
+  void sendA(String value) => emitEffect(EffectA1(value));
+}
+
+class CubitB extends Cubit<int> with SideEffectMixin<int, EffectB> {
+  CubitB() : super(0);
+
+  void sendB(int code) => emitEffect(EffectB1(code));
+  void sendB2() => emitEffect(EffectB2());
+}
+
+// --- Tests ---
+
+void main() {
+  group('MultipleSideEffectListener', () {
+    testWidgets('renders the child widget', (tester) async {
+      final cubitA = CubitA();
+      final cubitB = CubitB();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultipleSideEffectListener(
+            listeners: [
+              SideEffectListener<CubitA, EffectA>(
+                bloc: cubitA,
+                listener: (context, effect) {},
+              ),
+              SideEffectListener<CubitB, EffectB>(
+                bloc: cubitB,
+                listener: (context, effect) {},
+              ),
+            ],
+            child: const Text('hello'),
+          ),
+        ),
+      );
+
+      expect(find.text('hello'), findsOneWidget);
+
+      await cubitA.close();
+      await cubitB.close();
+    });
+
+    testWidgets('each listener receives effects only from its bloc',
+        (tester) async {
+      final cubitA = CubitA();
+      final cubitB = CubitB();
+      final effectsA = <EffectA>[];
+      final effectsB = <EffectB>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultipleSideEffectListener(
+            listeners: [
+              SideEffectListener<CubitA, EffectA>(
+                bloc: cubitA,
+                listener: (context, effect) => effectsA.add(effect),
+              ),
+              SideEffectListener<CubitB, EffectB>(
+                bloc: cubitB,
+                listener: (context, effect) => effectsB.add(effect),
+              ),
+            ],
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      cubitA.sendA('nav');
+      await tester.pump();
+
+      expect(effectsA, [EffectA1('nav')]);
+      expect(effectsB, isEmpty);
+
+      cubitB.sendB(42);
+      await tester.pump();
+
+      expect(effectsA, [EffectA1('nav')]);
+      expect(effectsB, [EffectB1(42)]);
+
+      await cubitA.close();
+      await cubitB.close();
+    });
+
+    testWidgets('both listeners receive effects independently',
+        (tester) async {
+      final cubitA = CubitA();
+      final cubitB = CubitB();
+      final effectsA = <EffectA>[];
+      final effectsB = <EffectB>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultipleSideEffectListener(
+            listeners: [
+              SideEffectListener<CubitA, EffectA>(
+                bloc: cubitA,
+                listener: (context, effect) => effectsA.add(effect),
+              ),
+              SideEffectListener<CubitB, EffectB>(
+                bloc: cubitB,
+                listener: (context, effect) => effectsB.add(effect),
+              ),
+            ],
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      cubitA.sendA('first');
+      cubitB.sendB(1);
+      cubitA.sendA('second');
+      cubitB.sendB(2);
+      await tester.pump();
+
+      expect(effectsA, [EffectA1('first'), EffectA1('second')]);
+      expect(effectsB, [EffectB1(1), EffectB1(2)]);
+
+      await cubitA.close();
+      await cubitB.close();
+    });
+
+    testWidgets('works with blocs provided via BlocProvider context',
+        (tester) async {
+      final cubitA = CubitA();
+      final cubitB = CubitB();
+      final effectsA = <EffectA>[];
+      final effectsB = <EffectB>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<CubitA>.value(value: cubitA),
+              BlocProvider<CubitB>.value(value: cubitB),
+            ],
+            child: MultipleSideEffectListener(
+              listeners: [
+                SideEffectListener<CubitA, EffectA>(
+                  listener: (context, effect) => effectsA.add(effect),
+                ),
+                SideEffectListener<CubitB, EffectB>(
+                  listener: (context, effect) => effectsB.add(effect),
+                ),
+              ],
+              child: const SizedBox(),
+            ),
+          ),
+        ),
+      );
+
+      cubitA.sendA('ctx');
+      cubitB.sendB(99);
+      await tester.pump();
+
+      expect(effectsA, [EffectA1('ctx')]);
+      expect(effectsB, [EffectB1(99)]);
+
+      await cubitA.close();
+      await cubitB.close();
+    });
+
+    testWidgets('cleans up subscriptions on dispose', (tester) async {
+      final cubitA = CubitA();
+      final cubitB = CubitB();
+      final effectsA = <EffectA>[];
+      final effectsB = <EffectB>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultipleSideEffectListener(
+            listeners: [
+              SideEffectListener<CubitA, EffectA>(
+                bloc: cubitA,
+                listener: (context, effect) => effectsA.add(effect),
+              ),
+              SideEffectListener<CubitB, EffectB>(
+                bloc: cubitB,
+                listener: (context, effect) => effectsB.add(effect),
+              ),
+            ],
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      // Remove the widget tree to trigger dispose.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+      cubitA.sendA('after');
+      cubitB.sendB(0);
+      await tester.pump();
+
+      expect(effectsA, isEmpty);
+      expect(effectsB, isEmpty);
+
+      await cubitA.close();
+      await cubitB.close();
+    });
+
+    testWidgets('listenWhen works inside multi-listener', (tester) async {
+      final cubitB = CubitB();
+      final effectsB = <EffectB>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MultipleSideEffectListener(
+            listeners: [
+              SideEffectListener<CubitB, EffectB>(
+                bloc: cubitB,
+                listenWhen: (effect) => effect is EffectB1,
+                listener: (context, effect) => effectsB.add(effect),
+              ),
+            ],
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      cubitB.sendB(1);
+      cubitB.sendB2();
+      cubitB.sendB(2);
+      await tester.pump();
+
+      expect(effectsB, [EffectB1(1), EffectB1(2)]);
+
+      await cubitB.close();
+    });
+  });
+}

--- a/packages/flutter_bloc_one_shot/test/side_effect_provider_test.dart
+++ b/packages/flutter_bloc_one_shot/test/side_effect_provider_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_bloc_one_shot/flutter_bloc_one_shot.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// --- Test helpers ---
+
+sealed class TestEffect {}
+
+class NavigateEffect extends TestEffect {
+  final String route;
+  NavigateEffect(this.route);
+
+  @override
+  bool operator ==(Object other) =>
+      other is NavigateEffect && other.route == route;
+
+  @override
+  int get hashCode => route.hashCode;
+
+  @override
+  String toString() => 'NavigateEffect($route)';
+}
+
+class ShowSnackbar extends TestEffect {
+  final String message;
+  ShowSnackbar(this.message);
+
+  @override
+  bool operator ==(Object other) =>
+      other is ShowSnackbar && other.message == message;
+
+  @override
+  int get hashCode => message.hashCode;
+
+  @override
+  String toString() => 'ShowSnackbar($message)';
+}
+
+class TestCubit extends Cubit<int> with SideEffectMixin<int, TestEffect> {
+  TestCubit() : super(0);
+
+  void navigate(String route) => emitEffect(NavigateEffect(route));
+  void showMessage(String msg) => emitEffect(ShowSnackbar(msg));
+  void increment() => emit(state + 1);
+}
+
+// --- Tests ---
+
+void main() {
+  group('SideEffectProvider', () {
+    testWidgets('renders the child widget', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>(
+            create: (_) => TestCubit(),
+            listener: (context, effect) {},
+            child: const Text('child'),
+          ),
+        ),
+      );
+
+      expect(find.text('child'), findsOneWidget);
+    });
+
+    testWidgets('provides the bloc to the child context', (tester) async {
+      late TestCubit resolvedCubit;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>(
+            create: (_) => TestCubit(),
+            listener: (context, effect) {},
+            child: Builder(
+              builder: (context) {
+                resolvedCubit = context.read<TestCubit>();
+                return Text('state: ${resolvedCubit.state}');
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('state: 0'), findsOneWidget);
+      expect(resolvedCubit, isA<TestCubit>());
+    });
+
+    testWidgets('calls listener when effect is emitted', (tester) async {
+      late TestCubit cubit;
+      final effects = <TestEffect>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>(
+            create: (_) => TestCubit(),
+            listener: (context, effect) => effects.add(effect),
+            child: Builder(
+              builder: (context) {
+                cubit = context.read<TestCubit>();
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      cubit.navigate('/home');
+      await tester.pump();
+
+      expect(effects, [NavigateEffect('/home')]);
+    });
+
+    testWidgets('applies listenWhen filter', (tester) async {
+      late TestCubit cubit;
+      final effects = <TestEffect>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>(
+            create: (_) => TestCubit(),
+            listenWhen: (effect) => effect is NavigateEffect,
+            listener: (context, effect) => effects.add(effect),
+            child: Builder(
+              builder: (context) {
+                cubit = context.read<TestCubit>();
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      cubit.navigate('/home');
+      cubit.showMessage('ignored');
+      cubit.navigate('/settings');
+      await tester.pump();
+
+      expect(effects, [NavigateEffect('/home'), NavigateEffect('/settings')]);
+    });
+
+    testWidgets('.value provides an existing bloc and listens to effects', (
+      tester,
+    ) async {
+      final cubit = TestCubit();
+      final effects = <TestEffect>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>.value(
+            value: cubit,
+            listener: (context, effect) => effects.add(effect),
+            child: Builder(
+              builder: (context) {
+                // Verify bloc is accessible via context.
+                final resolved = context.read<TestCubit>();
+                expect(resolved, same(cubit));
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      cubit.navigate('/value');
+      await tester.pump();
+
+      expect(effects, [NavigateEffect('/value')]);
+
+      await cubit.close();
+    });
+
+    testWidgets('.value does not close the bloc on dispose', (tester) async {
+      final cubit = TestCubit();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>.value(
+            value: cubit,
+            listener: (context, effect) {},
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      // Dispose widget tree.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+      // Bloc should still be open — emitting state should not throw.
+      expect(() => cubit.increment(), returnsNormally);
+
+      await cubit.close();
+    });
+
+    testWidgets('create constructor closes the bloc on dispose', (
+      tester,
+    ) async {
+      late TestCubit createdCubit;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>(
+            create: (_) {
+              createdCubit = TestCubit();
+              return createdCubit;
+            },
+            listener: (context, effect) {},
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      // Dispose widget tree.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+      // Bloc should be closed — emitting state should throw.
+      expect(() => createdCubit.increment(), throwsStateError);
+    });
+
+    testWidgets('lazy: false creates the bloc immediately', (tester) async {
+      var created = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>(
+            create: (_) {
+              created = true;
+              return TestCubit();
+            },
+            lazy: false,
+            listener: (context, effect) {},
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      expect(created, isTrue);
+    });
+
+    testWidgets('receives multiple effects in order', (tester) async {
+      late TestCubit cubit;
+      final effects = <TestEffect>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SideEffectProvider<TestCubit, TestEffect>(
+            create: (_) => TestCubit(),
+            listener: (context, effect) => effects.add(effect),
+            child: Builder(
+              builder: (context) {
+                cubit = context.read<TestCubit>();
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      cubit.navigate('/a');
+      cubit.showMessage('hello');
+      cubit.navigate('/b');
+      await tester.pump();
+
+      expect(effects, [
+        NavigateEffect('/a'),
+        ShowSnackbar('hello'),
+        NavigateEffect('/b'),
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add `MultipleSideEffectListener` widget to merge multiple `SideEffectListener` widgets without nesting
- Add `SideEffectProvider` widget that combines `BlocProvider` and `SideEffectListener` into a single widget, reducing boilerplate
- Refactor `SideEffectListener` to extend `SingleChildStatefulWidget` for compatibility with `MultipleSideEffectListener`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Packages affected

- [ ] `bloc_one_shot`
- [x] `flutter_bloc_one_shot`
- [ ] `bloc_one_shot_test`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`dart test` / `flutter test`)
- [x] Static analysis passes (`dart analyze packages/`)
- [x] Code is formatted (`dart format packages/`)
- [x] I have updated the CHANGELOG of the affected packages
- [x] I have updated the README if the public API changed