### PR TITLE
feat: add CompositeEffectObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Modeling side effects as state causes:
 
 | Package | Description | Version |
 | --- | --- | --- |
-| [`bloc_one_shot`](packages/bloc_one_shot/) | Core Dart package — `EffectController`, `SideEffectMixin`, `EffectObserver` | `0.1.0` |
+| [`bloc_one_shot`](packages/bloc_one_shot/) | Core Dart package — `EffectController`, `SideEffectMixin`, `EffectObserver`, `CompositeEffectObserver` | `0.2.0` |
 | [`flutter_bloc_one_shot`](packages/flutter_bloc_one_shot/) | Flutter widgets — `SideEffectProvider`, `SideEffectListener`, `SideEffectConsumer`, `MultipleSideEffectListener` | `0.2.0` |
 | [`bloc_one_shot_test`](packages/bloc_one_shot_test/) | Test utilities — `blocEffectTest()` | `0.1.0` |
 
@@ -194,6 +194,16 @@ class LoggingEffectObserver extends EffectObserver {
 }
 ```
 
+Use `CompositeEffectObserver` to combine multiple observers:
+
+```dart
+EffectObserver.instance = CompositeEffectObserver([
+  LoggingEffectObserver(),
+  AnalyticsEffectObserver(),
+  SentryEffectObserver(),
+]);
+```
+
 ## Testing
 
 Use `blocEffectTest` to verify both states and effects:
@@ -261,6 +271,10 @@ Buffered broadcast stream controller. Effects emitted before any listener subscr
 ### `EffectObserver`
 
 Set `EffectObserver.instance` at app startup to observe all effects globally.
+
+### `CompositeEffectObserver`
+
+An `EffectObserver` that delegates to multiple child observers. Accepts a `List<EffectObserver>`.
 
 ## How Buffering Works
 

--- a/packages/bloc_one_shot/CHANGELOG.md
+++ b/packages/bloc_one_shot/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Add `CompositeEffectObserver` to delegate to multiple `EffectObserver` instances.
+
 ## 0.1.0
 
 - Initial release.

--- a/packages/bloc_one_shot/README.md
+++ b/packages/bloc_one_shot/README.md
@@ -199,6 +199,25 @@ class AppEffectObserver extends EffectObserver {
 | `onEffect(bloc, effect)` | `void` | Called on every `emitEffect` across the app |
 | `EffectObserver.instance` | `static EffectObserver?` | Global instance — set at app startup |
 
+### `CompositeEffectObserver`
+
+An `EffectObserver` that delegates to multiple child observers. Use this when you need several independent observers (e.g. logging, analytics, crash reporting) without manually combining them into a single class.
+
+```dart
+void main() {
+  EffectObserver.instance = CompositeEffectObserver([
+    LoggingEffectObserver(),
+    AnalyticsEffectObserver(),
+    SentryEffectObserver(),
+  ]);
+  runApp(MyApp());
+}
+```
+
+| Member | Type | Description |
+|---|---|---|
+| `observers` | `List<EffectObserver>` | The list of child observers to notify |
+
 ## Comparison with Alternatives
 
 | Feature | `bloc_one_shot` | `bloc_presentation` | `bloc_one_shots` | `side_effect_bloc` |

--- a/packages/bloc_one_shot/lib/bloc_one_shot.dart
+++ b/packages/bloc_one_shot/lib/bloc_one_shot.dart
@@ -4,6 +4,7 @@
 /// and global [EffectObserver] for logging and analytics.
 library bloc_one_shot;
 
+export 'src/composite_effect_observer.dart';
 export 'src/effect_controller.dart';
 export 'src/effect_observer.dart';
 export 'src/side_effect_mixin.dart';

--- a/packages/bloc_one_shot/lib/src/composite_effect_observer.dart
+++ b/packages/bloc_one_shot/lib/src/composite_effect_observer.dart
@@ -1,0 +1,34 @@
+import 'package:bloc/bloc.dart';
+
+import 'effect_observer.dart';
+
+/// An [EffectObserver] that delegates to multiple child observers.
+///
+/// Use this when you need several independent observers (e.g. logging,
+/// analytics, crash reporting) without manually combining them into a
+/// single class.
+///
+/// ```dart
+/// void main() {
+///   EffectObserver.instance = CompositeEffectObserver([
+///     LoggingEffectObserver(),
+///     AnalyticsEffectObserver(),
+///     SentryEffectObserver(),
+///   ]);
+///   runApp(MyApp());
+/// }
+/// ```
+class CompositeEffectObserver extends EffectObserver {
+  /// Creates a [CompositeEffectObserver] that delegates to [observers].
+  CompositeEffectObserver(this.observers);
+
+  /// The list of child observers to notify.
+  final List<EffectObserver> observers;
+
+  @override
+  void onEffect(BlocBase<dynamic> bloc, Object? effect) {
+    for (final observer in observers) {
+      observer.onEffect(bloc, effect);
+    }
+  }
+}

--- a/packages/bloc_one_shot/test/composite_effect_observer_test.dart
+++ b/packages/bloc_one_shot/test/composite_effect_observer_test.dart
@@ -1,0 +1,111 @@
+import 'package:bloc/bloc.dart';
+import 'package:bloc_one_shot/bloc_one_shot.dart';
+import 'package:test/test.dart';
+
+class _TestObserver extends EffectObserver {
+  final List<(BlocBase<dynamic>, Object?)> calls = [];
+
+  @override
+  void onEffect(BlocBase<dynamic> bloc, Object? effect) {
+    calls.add((bloc, effect));
+  }
+}
+
+class _TestCubit extends Cubit<int> with SideEffectMixin<int, String> {
+  _TestCubit() : super(0);
+}
+
+void main() {
+  group('CompositeEffectObserver', () {
+    tearDown(() {
+      EffectObserver.instance = null;
+    });
+
+    test('delegates to all child observers', () {
+      final observer1 = _TestObserver();
+      final observer2 = _TestObserver();
+      final observer3 = _TestObserver();
+
+      EffectObserver.instance = CompositeEffectObserver([
+        observer1,
+        observer2,
+        observer3,
+      ]);
+
+      final cubit = _TestCubit();
+      cubit.emitEffect('hello');
+
+      for (final observer in [observer1, observer2, observer3]) {
+        expect(observer.calls, hasLength(1));
+        expect(observer.calls.first.$1, cubit);
+        expect(observer.calls.first.$2, 'hello');
+      }
+
+      cubit.close();
+    });
+
+    test('delivers multiple effects in order to all observers', () {
+      final observer1 = _TestObserver();
+      final observer2 = _TestObserver();
+
+      EffectObserver.instance = CompositeEffectObserver([observer1, observer2]);
+
+      final cubit = _TestCubit();
+      cubit.emitEffect('a');
+      cubit.emitEffect('b');
+      cubit.emitEffect('c');
+
+      for (final observer in [observer1, observer2]) {
+        expect(observer.calls.map((c) => c.$2).toList(), ['a', 'b', 'c']);
+      }
+
+      cubit.close();
+    });
+
+    test('works with an empty list of observers', () {
+      EffectObserver.instance = CompositeEffectObserver([]);
+
+      final cubit = _TestCubit();
+      expect(() => cubit.emitEffect('hello'), returnsNormally);
+
+      cubit.close();
+    });
+
+    test('works with a single observer', () {
+      final observer = _TestObserver();
+      EffectObserver.instance = CompositeEffectObserver([observer]);
+
+      final cubit = _TestCubit();
+      cubit.emitEffect('single');
+
+      expect(observer.calls, hasLength(1));
+      expect(observer.calls.first.$2, 'single');
+
+      cubit.close();
+    });
+
+    test('receives effects from multiple blocs', () {
+      final observer1 = _TestObserver();
+      final observer2 = _TestObserver();
+
+      EffectObserver.instance = CompositeEffectObserver([observer1, observer2]);
+
+      final cubit1 = _TestCubit();
+      final cubit2 = _TestCubit();
+
+      cubit1.emitEffect('from_1');
+      cubit2.emitEffect('from_2');
+
+      for (final observer in [observer1, observer2]) {
+        expect(observer.calls, hasLength(2));
+        expect(observer.calls[0].$1, cubit1);
+        expect(observer.calls[0].$2, 'from_1');
+        expect(observer.calls[1].$1, cubit2);
+        expect(observer.calls[1].$2, 'from_2');
+      }
+
+      cubit1.close();
+      cubit2.close();
+    });
+  });
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add `CompositeEffectObserver` to delegate to multiple `EffectObserver` instances, enabling clean separation of concerns (logging, analytics, crash reporting)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Packages affected

- [x] `bloc_one_shot`
- [ ] `flutter_bloc_one_shot`
- [ ] `bloc_one_shot_test`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`dart test` / `flutter test`)
- [x] Static analysis passes (`dart analyze packages/`)
- [x] Code is formatted (`dart format packages/`)
- [x] I have updated the CHANGELOG of the affected packages
- [x] I have updated the README if the public API changed

Closes #2